### PR TITLE
feat: add Compound V3 and Aave V3 portfolios

### DIFF
--- a/src/interfaces/IAave.sol
+++ b/src/interfaces/IAave.sol
@@ -12,3 +12,11 @@ interface ILendingPool {
     function deposit(address asset, uint256 amount, address onBehalfOf, uint16 referralCode) external;
     function withdraw(address asset, uint256 amount, address to) external;
 }
+
+// Aave V3 interfaces. We can use the same IAToken interface, but need a new pool interface since
+// the `deposit` method is deprecated (it still exists and is an alias for `supply`).
+interface IV3Pool {
+    // The referral program is currently inactive. so pass 0 as the referralCode.
+    function supply(address asset, uint256 amount, address onBehalfOf, uint16 referralCode) external;
+    function withdraw(address asset, uint256 amount, address to) external;
+}

--- a/src/interfaces/ICErc20.sol
+++ b/src/interfaces/ICErc20.sol
@@ -1,5 +1,6 @@
 pragma solidity 0.8.13;
 
+// Compound V2 interfaces.
 interface ICErc20 {
     function accrualBlockNumber() external view returns (uint256);
     function balanceOf(address owner) external view returns (uint256);
@@ -15,4 +16,14 @@ interface ICErc20 {
     function totalReserves() external view returns (uint256);
     function totalSupply() external view returns (uint256);
     function underlying() external view returns (address);
+}
+
+// Interfaces for Compound III, which is called Comet.
+interface IComet {
+    function balanceOf(address account) external view returns (uint256);
+    function baseToken() external view returns (address);
+    function supply(address asset, uint256 amount) external;
+    function transfer(address dst, uint256 amount) external returns (bool);
+    function withdraw(address asset, uint256 amount) external;
+    function withdrawTo(address to, address asset, uint256 amount) external;
 }

--- a/src/portfolios/AaveV3USDCPortfolio.sol
+++ b/src/portfolios/AaveV3USDCPortfolio.sol
@@ -1,0 +1,171 @@
+//SPDX-License-Identifier: BSD 3-Clause
+pragma solidity 0.8.13;
+
+import {Registry} from "../Registry.sol";
+import {Entity} from "../Entity.sol";
+import {Portfolio} from "../Portfolio.sol";
+import {IAToken, IV3Pool} from "../interfaces/IAave.sol";
+import {Auth} from "../lib/auth/Auth.sol";
+import {Math} from "../lib/Math.sol";
+import {ERC20} from "solmate/tokens/ERC20.sol";
+import {SafeTransferLib} from "solmate/utils/SafeTransferLib.sol";
+
+error SyncAfterShutdown();
+
+contract AaveV3USDCPortfolio is Portfolio {
+    using SafeTransferLib for ERC20;
+    using Math for uint256;
+
+    IV3Pool public constant aavePool = IV3Pool(0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2);
+    IAToken public constant ausdc = IAToken(0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c);
+    uint16 internal constant referralCode = 0; // Referral program is currently inactive.
+
+    error AssetMismatch();
+
+    /**
+     * @param _registry Endaoment registry.
+     * @param _asset Underlying ERC20 token for portfolio (this should match the registry's base token, i.e. USDC).
+     * @param _cap Amount of baseToken that this portfolio's asset balance should not exceed.
+     * @param _depositFee TODO
+     * @param _redemptionFee Percentage fee as ZOC that should go to treasury on redemption. (100 = 1%).
+     */
+    constructor(Registry _registry, address _asset, uint256 _cap, uint256 _depositFee, uint256 _redemptionFee)
+        Portfolio(_registry, _asset, "Aave V3 USDC Portfolio Shares", "aEthUSDC-PS", _cap, _depositFee, _redemptionFee)
+    {
+        // The `asset` should match the base token, which means we expect it to be USDC. So we
+        // execute some checks to make sure inputs are consistent.
+        address baseToken = address(registry.baseToken());
+        if (baseToken != ausdc.UNDERLYING_ASSET_ADDRESS()) revert AssetMismatch();
+        if (baseToken != _asset) revert AssetMismatch();
+
+        // Inputs are consistent, so we can approve the lending pool to spend our USDC.
+        ERC20(asset).safeApprove(address(aavePool), type(uint256).max);
+    }
+
+    /**
+     * @notice Returns the USDC value of all aUSDC held by this contract.
+     */
+    function totalAssets() public view override returns (uint256) {
+        return ausdc.balanceOf(address(this));
+    }
+
+    /**
+     * @notice Takes some amount of assets from this portfolio as assets under management fee.
+     * @param _amountAssets Amount of assets to take.
+     */
+    function takeFees(uint256 _amountAssets) external override requiresAuth {
+        aavePool.withdraw(address(asset), _amountAssets, registry.treasury());
+        emit FeesTaken(_amountAssets);
+    }
+
+    /**
+     * @inheritdoc Portfolio
+     * @dev Rounding down in both of these favors the portfolio, so the user gets slightly less and the portfolio gets slightly more,
+     * that way it prevents a situation where the user is owed x but the vault only has x - epsilon, where epsilon is some tiny number
+     * due to rounding error.
+     */
+    function convertToShares(uint256 _assets) public view override returns (uint256) {
+        uint256 _supply = totalSupply; // Saves an extra SLOAD if totalSupply is non-zero.
+        return _supply == 0 ? _assets : _assets.mulDivDown(_supply, totalAssets());
+    }
+
+    /**
+     * @inheritdoc Portfolio
+     * @dev Rounding down in both of these favors the portfolio, so the user gets slightly less and the portfolio gets slightly more,
+     * that way it prevents a situation where the user is owed x but the vault only has x - epsilon, where epsilon is some tiny number
+     * due to rounding error.
+     */
+    function convertToAssets(uint256 _shares) public view override returns (uint256) {
+        uint256 _supply = totalSupply; // Saves an extra SLOAD if totalSupply is non-zero.
+        return _supply == 0 ? _shares : _shares.mulDivDown(totalAssets(), _supply);
+    }
+
+    /**
+     * @dev Rounding down in both of these favors the portfolio, so the user gets slightly less and the portfolio gets slightly more,
+     * that way it prevents a situation where the user is owed x but the vault only has x - epsilon, where epsilon is some tiny number
+     * due to rounding error.
+     */
+    function convertToAssetsShutdown(uint256 _shares) public view returns (uint256) {
+        uint256 _supply = totalSupply; // Saves an extra SLOAD if totalSupply is non-zero.
+        return _supply == 0 ? _shares : _shares.mulDivDown(ERC20(asset).balanceOf(address(this)), _supply);
+    }
+
+    /**
+     * @inheritdoc Portfolio
+     * @dev Deposit the specified number of base token assets, subtract a fee, and deposit into Aave. The `_data`
+     * parameter is unused.
+     */
+    function deposit(uint256 _amountBaseToken, bytes calldata /* _data */ ) external override returns (uint256) {
+        if (didShutdown) revert DepositAfterShutdown();
+        if (!_isEntity(Entity(payable(msg.sender)))) revert NotEntity();
+        (uint256 _amountNet, uint256 _amountFee) = _calculateFee(_amountBaseToken, depositFee);
+        if (totalAssets() + _amountNet > cap) revert ExceedsCap();
+
+        uint256 _shares = convertToShares(_amountNet);
+        if (_shares == 0) revert RoundsToZero();
+
+        ERC20(asset).safeTransferFrom(msg.sender, address(this), _amountBaseToken);
+        ERC20(asset).safeTransfer(registry.treasury(), _amountFee);
+        _mint(msg.sender, _shares);
+        emit Deposit(msg.sender, msg.sender, _amountNet, _shares, _amountBaseToken, _amountFee);
+
+        aavePool.supply(asset, _amountNet, address(this), referralCode);
+        return _shares;
+    }
+
+    /**
+     * @inheritdoc Portfolio
+     * @dev Redeem the specified number of shares to get back the underlying base token assets, which are
+     * withdrawn from Aave. If the utilization of the Aave market is too high, there may be insufficient
+     * funds to redeem and this method will revert. The `_data` parameter is unused.
+     */
+    function redeem(uint256 _amountShares, bytes calldata /* _data */ ) external override returns (uint256) {
+        if (didShutdown) return _redeemShutdown(_amountShares);
+        uint256 _assets = convertToAssets(_amountShares);
+        if (_assets == 0) revert RoundsToZero();
+
+        aavePool.withdraw(asset, _assets, address(this));
+        _burn(msg.sender, _amountShares);
+
+        (uint256 _amountNet, uint256 _amountFee) = _calculateFee(_assets, depositFee);
+        ERC20(asset).safeTransfer(registry.treasury(), _amountFee);
+        ERC20(asset).safeTransfer(msg.sender, _amountNet);
+        emit Redeem(msg.sender, msg.sender, _amountNet, _amountShares, _amountNet, _amountFee);
+        return _amountNet;
+    }
+
+    /**
+     * @notice Deposits stray USDC for the benefit of everyone else
+     */
+    function sync() external requiresAuth {
+        if (didShutdown) revert SyncAfterShutdown();
+        aavePool.supply(asset, ERC20(asset).balanceOf(address(this)), address(this), referralCode);
+    }
+
+    /**
+     * @inheritdoc Portfolio
+     */
+    function shutdown(bytes calldata /* data */ ) external override requiresAuth returns (uint256) {
+        if (didShutdown) revert DidShutdown();
+        uint256 _assetsOut = totalAssets();
+        didShutdown = true;
+        aavePool.withdraw(asset, _assetsOut, address(this));
+        emit Shutdown(_assetsOut, _assetsOut);
+        return _assetsOut;
+    }
+
+    /**
+     * @notice Handles redemption after shutdown, exchanging shares for baseToken.
+     * @param _amountShares Shares being redeemed.
+     * @return Amount of baseToken received.
+     */
+    function _redeemShutdown(uint256 _amountShares) private returns (uint256) {
+        uint256 _baseTokenOut = convertToAssetsShutdown(_amountShares);
+        _burn(msg.sender, _amountShares);
+        (uint256 _netAmount, uint256 _fee) = _calculateFee(_baseTokenOut, redemptionFee);
+        ERC20(asset).safeTransfer(registry.treasury(), _fee);
+        ERC20(asset).safeTransfer(msg.sender, _netAmount);
+        emit Redeem(msg.sender, msg.sender, _baseTokenOut, _amountShares, _netAmount, _fee);
+        return _netAmount;
+    }
+}

--- a/src/portfolios/AaveV3USDCPortfolio.sol
+++ b/src/portfolios/AaveV3USDCPortfolio.sol
@@ -28,6 +28,9 @@ contract AaveV3USDCPortfolio is Portfolio {
     /// @dev Thrown when there's a mismatch between constructor arguments and the underlying asset.
     error AssetMismatch();
 
+    /// @dev Thrown when a slippage parameter cannot be met on deposit or redeem.
+    error Slippage();
+
     /**
      * @param _registry Endaoment registry.
      * @param _asset Underlying ERC20 token for portfolio (this should match the registry's base token, i.e. USDC).
@@ -101,7 +104,7 @@ contract AaveV3USDCPortfolio is Portfolio {
      * @dev Deposit the specified number of base token assets, subtract a fee, and deposit into Aave. The `_data`
      * parameter is unused.
      */
-    function deposit(uint256 _amountBaseToken, bytes calldata /* _data */ ) external override returns (uint256) {
+    function deposit(uint256 _amountBaseToken, bytes memory /* _data */ ) public override returns (uint256) {
         if (didShutdown) revert DepositAfterShutdown();
         if (!_isEntity(Entity(payable(msg.sender)))) revert NotEntity();
         (uint256 _amountNet, uint256 _amountFee) = _calculateFee(_amountBaseToken, depositFee);
@@ -120,12 +123,22 @@ contract AaveV3USDCPortfolio is Portfolio {
     }
 
     /**
+     * @notice Exchange `_amountBaseToken` for some amount of Portfolio shares, reverting if the amount of shares
+     * received is less than `_minSharesOut`.
+     */
+    function deposit(uint256 _amountBaseToken, uint256 _minSharesOut) public returns (uint256) {
+        uint256 _shares = deposit(_amountBaseToken, "");
+        if (_shares < _minSharesOut) revert Slippage();
+        return _shares;
+    }
+
+    /**
      * @inheritdoc Portfolio
      * @dev Redeem the specified number of shares to get back the underlying base token assets, which are
      * withdrawn from Aave. If the utilization of the Aave market is too high, there may be insufficient
      * funds to redeem and this method will revert. The `_data` parameter is unused.
      */
-    function redeem(uint256 _amountShares, bytes calldata /* _data */ ) external override returns (uint256) {
+    function redeem(uint256 _amountShares, bytes memory /* _data */ ) public override returns (uint256) {
         if (didShutdown) return _redeemShutdown(_amountShares);
         uint256 _assets = convertToAssets(_amountShares);
         if (_assets == 0) revert RoundsToZero();
@@ -138,6 +151,16 @@ contract AaveV3USDCPortfolio is Portfolio {
         ERC20(asset).safeTransfer(msg.sender, _amountNet);
         emit Redeem(msg.sender, msg.sender, _amountNet, _amountShares, _amountNet, _amountFee);
         return _amountNet;
+    }
+
+    /**
+     * @notice Exchange `_amountShares` for some amount of baseToken, reverting if the amount of baseToken
+     * received is less than `_minBaseTokenOut`.
+     */
+    function redeem(uint256 _amountShares, uint256 _minBaseTokenOut) external returns (uint256) {
+        uint256 _baseTokenOut = redeem(_amountShares, "");
+        if (_baseTokenOut < _minBaseTokenOut) revert Slippage();
+        return _baseTokenOut;
     }
 
     /**

--- a/src/portfolios/AaveV3USDCPortfolio.sol
+++ b/src/portfolios/AaveV3USDCPortfolio.sol
@@ -16,18 +16,24 @@ contract AaveV3USDCPortfolio is Portfolio {
     using SafeTransferLib for ERC20;
     using Math for uint256;
 
+    /// @notice Address of the Aave V3 pool.
     IV3Pool public constant aavePool = IV3Pool(0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2);
-    IAToken public constant ausdc = IAToken(0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c);
-    uint16 internal constant referralCode = 0; // Referral program is currently inactive.
 
+    /// @notice Address of the Aave V3 USDC token.
+    IAToken public constant ausdc = IAToken(0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c);
+
+    /// @dev Referral program is currently inactive, so this is set to 0.
+    uint16 internal constant referralCode = 0;
+
+    /// @dev Thrown when there's a mismatch between constructor arguments and the underlying asset.
     error AssetMismatch();
 
     /**
      * @param _registry Endaoment registry.
      * @param _asset Underlying ERC20 token for portfolio (this should match the registry's base token, i.e. USDC).
      * @param _cap Amount of baseToken that this portfolio's asset balance should not exceed.
-     * @param _depositFee TODO
-     * @param _redemptionFee Percentage fee as ZOC that should go to treasury on redemption. (100 = 1%).
+     * @param _depositFee Percentage fee as ZOC that should go to treasury on deposit. (10,000 = 1%).
+     * @param _redemptionFee Percentage fee as ZOC that should go to treasury on redemption. (10,000 = 1%).
      */
     constructor(Registry _registry, address _asset, uint256 _cap, uint256 _depositFee, uint256 _redemptionFee)
         Portfolio(_registry, _asset, "Aave V3 USDC Portfolio Shares", "aEthUSDC-PS", _cap, _depositFee, _redemptionFee)
@@ -60,9 +66,9 @@ contract AaveV3USDCPortfolio is Portfolio {
 
     /**
      * @inheritdoc Portfolio
-     * @dev Rounding down in both of these favors the portfolio, so the user gets slightly less and the portfolio gets slightly more,
-     * that way it prevents a situation where the user is owed x but the vault only has x - epsilon, where epsilon is some tiny number
-     * due to rounding error.
+     * @dev Rounding down favors the portfolio, so the user gets slightly less and the portfolio gets slightly more,
+     * that way it prevents a situation where the user is owed x but the vault only has x - epsilon, where epsilon is
+     * some tiny number due to rounding error.
      */
     function convertToShares(uint256 _assets) public view override returns (uint256) {
         uint256 _supply = totalSupply; // Saves an extra SLOAD if totalSupply is non-zero.
@@ -71,9 +77,9 @@ contract AaveV3USDCPortfolio is Portfolio {
 
     /**
      * @inheritdoc Portfolio
-     * @dev Rounding down in both of these favors the portfolio, so the user gets slightly less and the portfolio gets slightly more,
-     * that way it prevents a situation where the user is owed x but the vault only has x - epsilon, where epsilon is some tiny number
-     * due to rounding error.
+     * @dev Rounding down favors the portfolio, so the user gets slightly less and the portfolio gets slightly more,
+     * that way it prevents a situation where the user is owed x but the vault only has x - epsilon, where epsilon is
+     * some tiny number due to rounding error.
      */
     function convertToAssets(uint256 _shares) public view override returns (uint256) {
         uint256 _supply = totalSupply; // Saves an extra SLOAD if totalSupply is non-zero.
@@ -81,9 +87,9 @@ contract AaveV3USDCPortfolio is Portfolio {
     }
 
     /**
-     * @dev Rounding down in both of these favors the portfolio, so the user gets slightly less and the portfolio gets slightly more,
-     * that way it prevents a situation where the user is owed x but the vault only has x - epsilon, where epsilon is some tiny number
-     * due to rounding error.
+     * @dev Rounding down favors the portfolio, so the user gets slightly less and the portfolio gets slightly more,
+     * that way it prevents a situation where the user is owed x but the vault only has x - epsilon, where epsilon is
+     * some tiny number due to rounding error.
      */
     function convertToAssetsShutdown(uint256 _shares) public view returns (uint256) {
         uint256 _supply = totalSupply; // Saves an extra SLOAD if totalSupply is non-zero.

--- a/src/portfolios/CompoundV3USDCPortfolio.sol
+++ b/src/portfolios/CompoundV3USDCPortfolio.sol
@@ -20,6 +20,9 @@ contract CompoundV3USDCPortfolio is Portfolio {
     /// @dev Thrown when there's a mismatch between constructor arguments and the underlying asset.
     error AssetMismatch();
 
+    /// @dev Thrown when a slippage parameter cannot be met on deposit or redeem.
+    error Slippage();
+
     /// @dev Thrown when the `sync` method is called after shutdown.
     error SyncAfterShutdown();
 
@@ -96,7 +99,7 @@ contract CompoundV3USDCPortfolio is Portfolio {
      * @dev Deposit the specified number of base token assets, subtract a fee, and deposit into Compound. The `_data`
      * parameter is unused.
      */
-    function deposit(uint256 _amountBaseToken, bytes calldata /* _data */ ) external override returns (uint256) {
+    function deposit(uint256 _amountBaseToken, bytes memory /* _data */ ) public override returns (uint256) {
         if (didShutdown) revert DepositAfterShutdown();
         if (!_isEntity(Entity(payable(msg.sender)))) revert NotEntity();
         (uint256 _amountNet, uint256 _amountFee) = _calculateFee(_amountBaseToken, depositFee);
@@ -115,12 +118,22 @@ contract CompoundV3USDCPortfolio is Portfolio {
     }
 
     /**
+     * @notice Exchange `_amountBaseToken` for some amount of Portfolio shares, reverting if the amount of shares
+     * received is less than `_minSharesOut`.
+     */
+    function deposit(uint256 _amountBaseToken, uint256 _minSharesOut) public returns (uint256) {
+        uint256 _shares = deposit(_amountBaseToken, "");
+        if (_shares < _minSharesOut) revert Slippage();
+        return _shares;
+    }
+
+    /**
      * @inheritdoc Portfolio
      * @dev Redeem the specified number of shares to get back the underlying base token assets, which are
      * withdrawn from Compound. If the utilization of the Compound market is too high, there may be insufficient
      * funds to redeem and this method will revert. The `_data` parameter is unused.
      */
-    function redeem(uint256 _amountShares, bytes calldata /* _data */ ) external override returns (uint256) {
+    function redeem(uint256 _amountShares, bytes memory /* _data */ ) public override returns (uint256) {
         if (didShutdown) return _redeemShutdown(_amountShares);
         uint256 _assets = convertToAssets(_amountShares);
         if (_assets == 0) revert RoundsToZero();
@@ -133,6 +146,16 @@ contract CompoundV3USDCPortfolio is Portfolio {
         ERC20(asset).safeTransfer(msg.sender, _amountNet);
         emit Redeem(msg.sender, msg.sender, _amountNet, _amountShares, _amountNet, _amountFee);
         return _amountNet;
+    }
+
+    /**
+     * @notice Exchange `_amountShares` for some amount of baseToken, reverting if the amount of baseToken
+     * received is less than `_minBaseTokenOut`.
+     */
+    function redeem(uint256 _amountShares, uint256 _minBaseTokenOut) external returns (uint256) {
+        uint256 _baseTokenOut = redeem(_amountShares, "");
+        if (_baseTokenOut < _minBaseTokenOut) revert Slippage();
+        return _baseTokenOut;
     }
 
     /**

--- a/src/portfolios/CompoundV3USDCPortfolio.sol
+++ b/src/portfolios/CompoundV3USDCPortfolio.sol
@@ -10,23 +10,25 @@ import {Math} from "../lib/Math.sol";
 import {ERC20} from "solmate/tokens/ERC20.sol";
 import {SafeTransferLib} from "solmate/utils/SafeTransferLib.sol";
 
-error SyncAfterShutdown();
-
 contract CompoundV3USDCPortfolio is Portfolio {
     using SafeTransferLib for ERC20;
     using Math for uint256;
 
+    /// @notice Address of the Compound III (Comet) USDC market/token.
     IComet public constant cusdc = IComet(0xc3d688B66703497DAA19211EEdff47f25384cdc3);
 
+    /// @dev Thrown when there's a mismatch between constructor arguments and the underlying asset.
     error AssetMismatch();
-    error CompoundError(uint256 errorCode);
+
+    /// @dev Thrown when the `sync` method is called after shutdown.
+    error SyncAfterShutdown();
 
     /**
      * @param _registry Endaoment registry.
      * @param _asset Underlying ERC20 asset token for portfolio.
      * @param _cap Amount of baseToken that this portfolio's asset balance should not exceed.
-     * @param _depositFee TODO
-     * @param _redemptionFee Percentage fee as ZOC that should go to treasury on redemption. (100 = 1%).
+     * @param _depositFee Percentage fee as ZOC that should go to treasury on deposit. (10,000 = 1%).
+     * @param _redemptionFee Percentage fee as ZOC that should go to treasury on redemption. (10,000 = 1%).
      */
     constructor(Registry _registry, address _asset, uint256 _cap, uint256 _depositFee, uint256 _redemptionFee)
         Portfolio(_registry, _asset, "Compound III USDC Portfolio Shares", "cUSDCv3-PS", _cap, _depositFee, _redemptionFee)
@@ -59,9 +61,9 @@ contract CompoundV3USDCPortfolio is Portfolio {
 
     /**
      * @inheritdoc Portfolio
-     * @dev Rounding down in both of these favors the portfolio, so the user gets slightly less and the portfolio gets slightly more,
-     * that way it prevents a situation where the user is owed x but the vault only has x - epsilon, where epsilon is some tiny number
-     * due to rounding error.
+     * @dev Rounding down favors the portfolio, so the user gets slightly less and the portfolio gets slightly more,
+     * that way it prevents a situation where the user is owed x but the vault only has x - epsilon, where epsilon is
+     * some tiny number due to rounding error.
      */
     function convertToShares(uint256 _assets) public view override returns (uint256) {
         uint256 _supply = totalSupply; // Saves an extra SLOAD if totalSupply is non-zero.
@@ -70,9 +72,9 @@ contract CompoundV3USDCPortfolio is Portfolio {
 
     /**
      * @inheritdoc Portfolio
-     * @dev Rounding down in both of these favors the portfolio, so the user gets slightly less and the portfolio gets slightly more,
-     * that way it prevents a situation where the user is owed x but the vault only has x - epsilon, where epsilon is some tiny number
-     * due to rounding error.
+     * @dev Rounding down favors the portfolio, so the user gets slightly less and the portfolio gets slightly more,
+     * that way it prevents a situation where the user is owed x but the vault only has x - epsilon, where epsilon is
+     * some tiny number due to rounding error.
      */
     function convertToAssets(uint256 _shares) public view override returns (uint256) {
         uint256 _supply = totalSupply; // Saves an extra SLOAD if totalSupply is non-zero.
@@ -80,9 +82,9 @@ contract CompoundV3USDCPortfolio is Portfolio {
     }
 
     /**
-     * @dev Rounding down in both of these favors the portfolio, so the user gets slightly less and the portfolio gets slightly more,
-     * that way it prevents a situation where the user is owed x but the vault only has x - epsilon, where epsilon is some tiny number
-     * due to rounding error.
+     * @dev Rounding down favors the portfolio, so the user gets slightly less and the portfolio gets slightly more,
+     * that way it prevents a situation where the user is owed x but the vault only has x - epsilon, where epsilon is
+     * some tiny number due to rounding error.
      */
     function convertToAssetsShutdown(uint256 _shares) public view returns (uint256) {
         uint256 _supply = totalSupply; // Saves an extra SLOAD if totalSupply is non-zero.

--- a/src/portfolios/CompoundV3USDCPortfolio.sol
+++ b/src/portfolios/CompoundV3USDCPortfolio.sol
@@ -1,0 +1,170 @@
+//SPDX-License-Identifier: BSD 3-Clause
+pragma solidity 0.8.13;
+
+import {Registry} from "../Registry.sol";
+import {Entity} from "../Entity.sol";
+import {Portfolio} from "../Portfolio.sol";
+import {IComet} from "../interfaces/ICErc20.sol";
+import {Auth} from "../lib/auth/Auth.sol";
+import {Math} from "../lib/Math.sol";
+import {ERC20} from "solmate/tokens/ERC20.sol";
+import {SafeTransferLib} from "solmate/utils/SafeTransferLib.sol";
+
+error SyncAfterShutdown();
+
+contract CompoundV3USDCPortfolio is Portfolio {
+    using SafeTransferLib for ERC20;
+    using Math for uint256;
+
+    IComet public constant cusdc = IComet(0xc3d688B66703497DAA19211EEdff47f25384cdc3);
+
+    error AssetMismatch();
+    error CompoundError(uint256 errorCode);
+
+    /**
+     * @param _registry Endaoment registry.
+     * @param _asset Underlying ERC20 asset token for portfolio.
+     * @param _cap Amount of baseToken that this portfolio's asset balance should not exceed.
+     * @param _depositFee TODO
+     * @param _redemptionFee Percentage fee as ZOC that should go to treasury on redemption. (100 = 1%).
+     */
+    constructor(Registry _registry, address _asset, uint256 _cap, uint256 _depositFee, uint256 _redemptionFee)
+        Portfolio(_registry, _asset, "Compound III USDC Portfolio Shares", "cUSDCv3-PS", _cap, _depositFee, _redemptionFee)
+    {
+        // The `asset` should match the base token, which means we expect it to be USDC. So we
+        // execute some checks to make sure inputs are consistent.
+        address baseToken = address(registry.baseToken());
+        if (baseToken != cusdc.baseToken()) revert AssetMismatch();
+        if (baseToken != asset) revert AssetMismatch();
+
+        // Inputs are consistent, so we can approve the pool to spend our USDC.
+        ERC20(asset).safeApprove(address(cusdc), type(uint256).max);
+    }
+
+    /**
+     * @notice Returns the USDC value of all cUSDC held by this contract.
+     */
+    function totalAssets() public view override returns (uint256) {
+        return cusdc.balanceOf(address(this));
+    }
+
+    /**
+     * @notice Takes some amount of assets from this portfolio as assets under management fee.
+     * @param _amountAssets Amount of assets to take.
+     */
+    function takeFees(uint256 _amountAssets) external override requiresAuth {
+        cusdc.withdrawTo(registry.treasury(), asset, _amountAssets);
+        emit FeesTaken(_amountAssets);
+    }
+
+    /**
+     * @inheritdoc Portfolio
+     * @dev Rounding down in both of these favors the portfolio, so the user gets slightly less and the portfolio gets slightly more,
+     * that way it prevents a situation where the user is owed x but the vault only has x - epsilon, where epsilon is some tiny number
+     * due to rounding error.
+     */
+    function convertToShares(uint256 _assets) public view override returns (uint256) {
+        uint256 _supply = totalSupply; // Saves an extra SLOAD if totalSupply is non-zero.
+        return _supply == 0 ? _assets : _assets.mulDivDown(_supply, totalAssets());
+    }
+
+    /**
+     * @inheritdoc Portfolio
+     * @dev Rounding down in both of these favors the portfolio, so the user gets slightly less and the portfolio gets slightly more,
+     * that way it prevents a situation where the user is owed x but the vault only has x - epsilon, where epsilon is some tiny number
+     * due to rounding error.
+     */
+    function convertToAssets(uint256 _shares) public view override returns (uint256) {
+        uint256 _supply = totalSupply; // Saves an extra SLOAD if totalSupply is non-zero.
+        return _supply == 0 ? _shares : _shares.mulDivDown(totalAssets(), _supply);
+    }
+
+    /**
+     * @dev Rounding down in both of these favors the portfolio, so the user gets slightly less and the portfolio gets slightly more,
+     * that way it prevents a situation where the user is owed x but the vault only has x - epsilon, where epsilon is some tiny number
+     * due to rounding error.
+     */
+    function convertToAssetsShutdown(uint256 _shares) public view returns (uint256) {
+        uint256 _supply = totalSupply; // Saves an extra SLOAD if totalSupply is non-zero.
+        return _supply == 0 ? _shares : _shares.mulDivDown(ERC20(asset).balanceOf(address(this)), _supply);
+    }
+
+    /**
+     * @inheritdoc Portfolio
+     * @dev Deposit the specified number of base token assets, subtract a fee, and deposit into Compound. The `_data`
+     * parameter is unused.
+     */
+    function deposit(uint256 _amountBaseToken, bytes calldata /* _data */ ) external override returns (uint256) {
+        if (didShutdown) revert DepositAfterShutdown();
+        if (!_isEntity(Entity(payable(msg.sender)))) revert NotEntity();
+        (uint256 _amountNet, uint256 _amountFee) = _calculateFee(_amountBaseToken, depositFee);
+        if (totalAssets() + _amountNet > cap) revert ExceedsCap();
+
+        uint256 _shares = convertToShares(_amountNet);
+        if (_shares == 0) revert RoundsToZero();
+
+        ERC20(asset).safeTransferFrom(msg.sender, address(this), _amountBaseToken);
+        ERC20(asset).safeTransfer(registry.treasury(), _amountFee);
+        _mint(msg.sender, _shares);
+        emit Deposit(msg.sender, msg.sender, _amountNet, _shares, _amountBaseToken, _amountFee);
+
+        cusdc.supply(asset, _amountNet);
+        return _shares;
+    }
+
+    /**
+     * @inheritdoc Portfolio
+     * @dev Redeem the specified number of shares to get back the underlying base token assets, which are
+     * withdrawn from Compound. If the utilization of the Compound market is too high, there may be insufficient
+     * funds to redeem and this method will revert. The `_data` parameter is unused.
+     */
+    function redeem(uint256 _amountShares, bytes calldata /* _data */ ) external override returns (uint256) {
+        if (didShutdown) return _redeemShutdown(_amountShares);
+        uint256 _assets = convertToAssets(_amountShares);
+        if (_assets == 0) revert RoundsToZero();
+
+        cusdc.withdraw(asset, _assets);
+        _burn(msg.sender, _amountShares);
+
+        (uint256 _amountNet, uint256 _amountFee) = _calculateFee(_assets, depositFee);
+        ERC20(asset).safeTransfer(registry.treasury(), _amountFee);
+        ERC20(asset).safeTransfer(msg.sender, _amountNet);
+        emit Redeem(msg.sender, msg.sender, _amountNet, _amountShares, _amountNet, _amountFee);
+        return _amountNet;
+    }
+
+    /**
+     * @notice Deposits stray USDC for the benefit of everyone else
+     */
+    function sync() external requiresAuth {
+        if (didShutdown) revert SyncAfterShutdown();
+        cusdc.supply(asset, ERC20(asset).balanceOf(address(this)));
+    }
+
+    /**
+     * @inheritdoc Portfolio
+     */
+    function shutdown(bytes calldata /* data */ ) external override requiresAuth returns (uint256) {
+        if (didShutdown) revert DidShutdown();
+        uint256 _assetsOut = totalAssets();
+        didShutdown = true;
+        cusdc.withdraw(asset, _assetsOut);
+        emit Shutdown(_assetsOut, _assetsOut);
+        return _assetsOut;
+    }
+
+    /**
+     * @notice Handles redemption after shutdown, exchanging shares for baseToken.
+     * @param _amountShares Shares being redeemed.
+     * @return Amount of baseToken received.
+     */
+    function _redeemShutdown(uint256 _amountShares) private returns (uint256) {
+        uint256 _baseTokenOut = convertToAssetsShutdown(_amountShares);
+        _burn(msg.sender, _amountShares);
+        (uint256 _netAmount, uint256 _fee) = _calculateFee(_baseTokenOut, redemptionFee);
+        ERC20(asset).safeTransfer(registry.treasury(), _fee);
+        ERC20(asset).safeTransfer(msg.sender, _netAmount);
+        emit Redeem(msg.sender, msg.sender, _baseTokenOut, _amountShares, _netAmount, _fee);
+        return _netAmount;
+    }
+}

--- a/src/portfolios/CompoundV3USDCPortfolio.sol
+++ b/src/portfolios/CompoundV3USDCPortfolio.sol
@@ -97,9 +97,9 @@ contract CompoundV3USDCPortfolio is Portfolio {
     /**
      * @inheritdoc Portfolio
      * @dev Deposit the specified number of base token assets, subtract a fee, and deposit into Compound. The `_data`
-     * parameter is unused.
+     * parameter is used to specify the expected `_minBaseTokenOut`.
      */
-    function deposit(uint256 _amountBaseToken, bytes memory /* _data */ ) public override returns (uint256) {
+    function deposit(uint256 _amountBaseToken, bytes calldata _minSharesOut) public override returns (uint256) {
         if (didShutdown) revert DepositAfterShutdown();
         if (!_isEntity(Entity(payable(msg.sender)))) revert NotEntity();
         (uint256 _amountNet, uint256 _amountFee) = _calculateFee(_amountBaseToken, depositFee);
@@ -107,6 +107,7 @@ contract CompoundV3USDCPortfolio is Portfolio {
 
         uint256 _shares = convertToShares(_amountNet);
         if (_shares == 0) revert RoundsToZero();
+        if (_shares < abi.decode(_minSharesOut, (uint256))) revert Slippage();
 
         ERC20(asset).safeTransferFrom(msg.sender, address(this), _amountBaseToken);
         ERC20(asset).safeTransfer(registry.treasury(), _amountFee);
@@ -118,44 +119,27 @@ contract CompoundV3USDCPortfolio is Portfolio {
     }
 
     /**
-     * @notice Exchange `_amountBaseToken` for some amount of Portfolio shares, reverting if the amount of shares
-     * received is less than `_minSharesOut`.
-     */
-    function deposit(uint256 _amountBaseToken, uint256 _minSharesOut) public returns (uint256) {
-        uint256 _shares = deposit(_amountBaseToken, "");
-        if (_shares < _minSharesOut) revert Slippage();
-        return _shares;
-    }
-
-    /**
      * @inheritdoc Portfolio
      * @dev Redeem the specified number of shares to get back the underlying base token assets, which are
      * withdrawn from Compound. If the utilization of the Compound market is too high, there may be insufficient
-     * funds to redeem and this method will revert. The `_data` parameter is unused.
+     * funds to redeem and this method will revert. The `_data` parameter is used to specify the expected
+     * `_minBaseTokenOut`.
      */
-    function redeem(uint256 _amountShares, bytes memory /* _data */ ) public override returns (uint256) {
+    function redeem(uint256 _amountShares, bytes calldata _minBaseTokenOut) public override returns (uint256) {
         if (didShutdown) return _redeemShutdown(_amountShares);
         uint256 _assets = convertToAssets(_amountShares);
         if (_assets == 0) revert RoundsToZero();
+        if (_assets < abi.decode(_minBaseTokenOut, (uint256))) revert Slippage();
 
         cusdc.withdraw(asset, _assets);
         _burn(msg.sender, _amountShares);
 
         (uint256 _amountNet, uint256 _amountFee) = _calculateFee(_assets, depositFee);
+
         ERC20(asset).safeTransfer(registry.treasury(), _amountFee);
         ERC20(asset).safeTransfer(msg.sender, _amountNet);
         emit Redeem(msg.sender, msg.sender, _amountNet, _amountShares, _amountNet, _amountFee);
         return _amountNet;
-    }
-
-    /**
-     * @notice Exchange `_amountShares` for some amount of baseToken, reverting if the amount of baseToken
-     * received is less than `_minBaseTokenOut`.
-     */
-    function redeem(uint256 _amountShares, uint256 _minBaseTokenOut) external returns (uint256) {
-        uint256 _baseTokenOut = redeem(_amountShares, "");
-        if (_baseTokenOut < _minBaseTokenOut) revert Slippage();
-        return _baseTokenOut;
     }
 
     /**

--- a/src/test/AaveV3USDCPortfolio.fork.t.sol
+++ b/src/test/AaveV3USDCPortfolio.fork.t.sol
@@ -94,13 +94,13 @@ contract AUPV3IntegrationTest is AaveV3USDCPortfolioTest {
 
     function deposit(address _who, uint256 _usdcAmount) public returns (uint256) {
         vm.prank(_who);
-        return portfolio.deposit(_usdcAmount, 0);
+        return portfolio.deposit(_usdcAmount, abi.encode(0));
     }
 
     function redeem(address _who) public returns (uint256) {
         uint256 _shares = portfolio.balanceOf(_who);
         vm.prank(_who);
-        return portfolio.redeem(_shares, 0);
+        return portfolio.redeem(_shares, abi.encode(0));
     }
 
     function test_Integration() public {
@@ -167,7 +167,7 @@ contract AUPV3IntegrationTest is AaveV3USDCPortfolioTest {
     function test_RevertIf_DepositSlippageTooHigh() public {
         vm.prank(alice);
         vm.expectRevert(AaveV3USDCPortfolio.Slippage.selector);
-        portfolio.deposit(30e6, 31e6);
+        portfolio.deposit(30e6, abi.encode(31e6));
     }
 
     function test_RevertIf_RedeemSlippageTooHigh() public {
@@ -175,7 +175,7 @@ contract AUPV3IntegrationTest is AaveV3USDCPortfolioTest {
 
         vm.prank(alice);
         vm.expectRevert(AaveV3USDCPortfolio.Slippage.selector);
-        portfolio.redeem(_shares, 31e6);
+        portfolio.redeem(_shares, abi.encode(31e6));
     }
 
     function testFuzz_DepositFailDidShutdown(uint256 _amount) public {

--- a/src/test/AaveV3USDCPortfolio.fork.t.sol
+++ b/src/test/AaveV3USDCPortfolio.fork.t.sol
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: BSD 3-Clause
+pragma solidity 0.8.13;
+
+import "./utils/DeployTest.sol";
+import "../Registry.sol";
+import {IAToken, ILendingPool} from "../interfaces/IAave.sol";
+import {ERC20} from "solmate/tokens/ERC20.sol";
+import {SafeTransferLib} from "solmate/utils/SafeTransferLib.sol";
+import {AaveV3USDCPortfolio} from "../portfolios/AaveV3USDCPortfolio.sol";
+
+error DepositAfterShutdown();
+error SyncAfterShutdown();
+
+contract AaveV3USDCPortfolioTest is DeployTest {
+    AaveV3USDCPortfolio portfolio;
+    Fund fund;
+
+    ERC20 usdc = ERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+    IAToken public constant ausdc = IAToken(0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c);
+    address manager = user1;
+    uint256 fundBalance = 1e27;
+
+    function setUp() public virtual override {
+        uint256 mainnetForkBlock = 17130422;
+        vm.createSelectFork(vm.rpcUrl("mainnet"), mainnetForkBlock);
+        DeployTest.setUp();
+
+        // Deploy new contracts with mainnet base token.
+        globalTestRegistry = new Registry(board, treasury, usdc);
+        orgFundFactory = new OrgFundFactory(globalTestRegistry);
+        vm.prank(board);
+        globalTestRegistry.setFactoryApproval(address(orgFundFactory), true);
+
+        // set donation fees to 0
+        // although it would be easier to do this in DeployTest, it causes testFuzz_UnmappedDefaultDonationFee to fail
+        vm.startPrank(board);
+        globalTestRegistry.setDefaultDonationFee(FundType, 0);
+        globalTestRegistry.setDefaultDonationFee(OrgType, 0);
+        vm.stopPrank();
+
+        // deploy a provisioned fund
+        fund = orgFundFactory.deployFund(manager, "soy sauce");
+        deal(address(usdc), manager, fundBalance);
+        vm.startPrank(manager);
+        usdc.approve(address(fund), fundBalance);
+        fund.donate(fundBalance);
+        vm.stopPrank();
+
+        // deploy portfolio
+        portfolio = new AaveV3USDCPortfolio(globalTestRegistry, address(usdc), type(uint256).max, 0, 0);
+        vm.prank(board);
+        globalTestRegistry.setPortfolioStatus(portfolio, true);
+    }
+}
+
+contract AUPV3Constructor is AaveV3USDCPortfolioTest {
+    function testFuzz_Constructor(uint256 _cap, uint256 _depositFee, uint256 _redemptionFee) public {
+        _redemptionFee = bound(_redemptionFee, 0, Math.ZOC);
+        AaveV3USDCPortfolio _portfolio =
+            new AaveV3USDCPortfolio(globalTestRegistry, address(usdc), _cap, _depositFee, _redemptionFee);
+
+        assertEq(_portfolio.name(), "Aave V3 USDC Portfolio Shares");
+        assertEq(_portfolio.symbol(), "aEthUSDC-PS");
+        assertEq(_portfolio.decimals(), usdc.decimals());
+        assertEq(_portfolio.asset(), address(usdc));
+        assertEq(_portfolio.cap(), _cap);
+        assertEq(_portfolio.depositFee(), _depositFee);
+        assertEq(_portfolio.redemptionFee(), _redemptionFee);
+        assertEq(_portfolio.totalAssets(), 0);
+        assertEq(_portfolio.convertToAssets(1e6), 1e6); // Starts at 1:1
+    }
+}
+
+contract AUPV3IntegrationTest is AaveV3USDCPortfolioTest {
+    using stdStorage for StdStorage;
+
+    address alice = address(0xaffab1e);
+    address bob = address(0xbaff1ed);
+
+    function setUp() public override {
+        super.setUp();
+        deal(address(usdc), alice, 100e6);
+        deal(address(usdc), bob, 100e6);
+
+        vm.prank(alice);
+        usdc.approve(address(portfolio), type(uint256).max);
+
+        vm.prank(bob);
+        usdc.approve(address(portfolio), type(uint256).max);
+
+        stdstore.target(address(globalTestRegistry)).sig("isActiveEntity(address)").with_key(alice).checked_write(true);
+        stdstore.target(address(globalTestRegistry)).sig("isActiveEntity(address)").with_key(bob).checked_write(true);
+    }
+
+    function deposit(address _who, uint256 _usdcAmount) public returns (uint256) {
+        vm.prank(_who);
+        return portfolio.deposit(_usdcAmount, hex"");
+    }
+
+    function redeem(address _who) public returns (uint256) {
+        uint256 _shares = portfolio.balanceOf(_who);
+        vm.prank(_who);
+        return portfolio.redeem(_shares, hex"");
+    }
+
+    function test_Integration() public {
+        // 1. Alice deposits 30M, exchange rate should be 1:1
+        uint256 _aliceShares = deposit(alice, 30e6);
+        assertEq(_aliceShares, 30e6);
+        assertEq(portfolio.balanceOf(alice), _aliceShares);
+        assertEq(portfolio.convertToAssets(portfolio.balanceOf(alice)), 30e6);
+        assertEq(portfolio.convertToShares(30e6), portfolio.balanceOf(alice));
+        assertEq(portfolio.totalSupply(), _aliceShares);
+        assertEq(portfolio.totalAssets(), _aliceShares);
+
+        // 2. Endaoment takes 5M fees, Alice now can redeem 25M
+        address _treasury = portfolio.registry().treasury();
+        assertEq(usdc.balanceOf(_treasury), 0);
+        vm.prank(board);
+        portfolio.takeFees(5e6);
+        assertEq(usdc.balanceOf(_treasury), 5e6);
+
+        assertEq(portfolio.convertToAssets(portfolio.balanceOf(alice)), 25e6);
+        assertEq(portfolio.totalAssets(), 25e6);
+        assertEq(portfolio.totalSupply(), _aliceShares);
+
+        // 3. Bob deposits 60M, Alice position remains unchanged
+        uint256 _bobShares = deposit(bob, 60e6);
+
+        // Same assertions about Alice's position
+        assertEq(_aliceShares, 30e6);
+        assertEq(portfolio.balanceOf(alice), _aliceShares);
+        assertEq(portfolio.convertToAssets(portfolio.balanceOf(alice)), 25e6);
+        assertEq(portfolio.totalAssets(), 85e6 + 1); // +1 due to rounding error.
+        assertEq(portfolio.totalSupply(), _aliceShares + _bobShares);
+        assertEq(portfolio.totalSupply(), 102e6);
+
+        // New assertions about Bob's position
+        assertEq(portfolio.balanceOf(bob), _bobShares);
+        assertEq(portfolio.convertToAssets(portfolio.balanceOf(bob)), 60e6);
+
+        // 4. Increase the Portfolio's aUSDC balance to simulate returns.
+        // We do this by pranking from a mainnet aUSDC whale and transferring it to the portfolio, because aTokens
+        // have a dynamic balanceOf method so `deal` doesn't work.
+        uint256 _startBalance = portfolio.totalAssets();
+        address whale = 0xD56353E0bDc41Ad232F9d11109868703c1e2b2B9; // Random whale with lots of Aave V3 aUSDC.
+        vm.prank(whale);
+        ausdc.transfer(address(portfolio), 100e6);
+        assertGt(portfolio.totalAssets(), _startBalance);
+
+        // 5. Alice and Bob should should get proportional amounts of USDC.
+        // Zero out their balances to simplify the math.
+        deal(address(usdc), alice, 0);
+        deal(address(usdc), bob, 0);
+
+        uint256 _aliceExpected = portfolio.totalAssets() * _aliceShares / portfolio.totalSupply();
+        uint256 _bobExpected = portfolio.totalAssets() * _bobShares / portfolio.totalSupply();
+
+        uint256 _aliceNet = redeem(alice);
+        uint256 _bobNet = redeem(bob);
+
+        assertEq(_aliceNet, _aliceExpected);
+        assertEq(_bobNet, _bobExpected);
+        assertEq(usdc.balanceOf(address(portfolio)), 0);
+    }
+
+    function testFuzz_DepositFailDidShutdown(uint256 _amount) public {
+        // deposit something into the portfolio, otherwise the the shutdown will fail on withdrawal
+        deposit(alice, 30e6);
+
+        _amount = bound(_amount, 1, 1e7 ether);
+        bytes memory _data = hex"";
+
+        // shutdown
+        vm.prank(board);
+        portfolio.shutdown(_data);
+
+        // try to deposit
+        vm.prank(manager);
+        vm.expectRevert(DepositAfterShutdown.selector);
+        fund.portfolioDeposit(portfolio, _amount, _data);
+    }
+
+    function test_SyncFailDidShutdown() public {
+        // deposit something into the portfolio, otherwise the the shutdown will fail on withdrawal
+        deposit(alice, 30e6);
+
+        bytes memory _data = hex"";
+
+        // shutdown
+        vm.prank(board);
+        portfolio.shutdown(_data);
+
+        // try to sync
+        vm.prank(board);
+        vm.expectRevert(SyncAfterShutdown.selector);
+        portfolio.sync();
+    }
+}

--- a/src/test/AaveV3USDCPortfolio.fork.t.sol
+++ b/src/test/AaveV3USDCPortfolio.fork.t.sol
@@ -94,13 +94,13 @@ contract AUPV3IntegrationTest is AaveV3USDCPortfolioTest {
 
     function deposit(address _who, uint256 _usdcAmount) public returns (uint256) {
         vm.prank(_who);
-        return portfolio.deposit(_usdcAmount, hex"");
+        return portfolio.deposit(_usdcAmount, 0);
     }
 
     function redeem(address _who) public returns (uint256) {
         uint256 _shares = portfolio.balanceOf(_who);
         vm.prank(_who);
-        return portfolio.redeem(_shares, hex"");
+        return portfolio.redeem(_shares, 0);
     }
 
     function test_Integration() public {
@@ -162,6 +162,20 @@ contract AUPV3IntegrationTest is AaveV3USDCPortfolioTest {
         assertEq(_aliceNet, _aliceExpected);
         assertEq(_bobNet, _bobExpected);
         assertEq(usdc.balanceOf(address(portfolio)), 0);
+    }
+
+    function test_RevertIf_DepositSlippageTooHigh() public {
+        vm.prank(alice);
+        vm.expectRevert(AaveV3USDCPortfolio.Slippage.selector);
+        portfolio.deposit(30e6, 31e6);
+    }
+
+    function test_RevertIf_RedeemSlippageTooHigh() public {
+        uint256 _shares = deposit(alice, 30e6);
+
+        vm.prank(alice);
+        vm.expectRevert(AaveV3USDCPortfolio.Slippage.selector);
+        portfolio.redeem(_shares, 31e6);
     }
 
     function testFuzz_DepositFailDidShutdown(uint256 _amount) public {

--- a/src/test/CompoundV3USDCPortfolio.fork.t.sol
+++ b/src/test/CompoundV3USDCPortfolio.fork.t.sol
@@ -57,7 +57,7 @@ contract CompoundV3USDCPortfolioTest is DeployTest {
     }
 }
 
-contract CUPConstructor is CompoundV3USDCPortfolioTest {
+contract CUPV3Constructor is CompoundV3USDCPortfolioTest {
     function testFuzz_Constructor(uint256 _cap, uint256 _depositFee, uint256 _redemptionFee) public {
         _redemptionFee = bound(_redemptionFee, 0, Math.ZOC);
         CompoundV3USDCPortfolio _portfolio =
@@ -75,7 +75,7 @@ contract CUPConstructor is CompoundV3USDCPortfolioTest {
     }
 }
 
-contract CUPIntegrationTest is CompoundV3USDCPortfolioTest {
+contract CUPV3IntegrationTest is CompoundV3USDCPortfolioTest {
     using stdStorage for StdStorage;
 
     address alice = address(0xaffab1e);
@@ -118,8 +118,11 @@ contract CUPIntegrationTest is CompoundV3USDCPortfolioTest {
         assertEq(portfolio.totalAssets(), _aliceShares - 1); // -1 again from rounding error.
 
         // 2. Endaoment takes 5M fees, Alice now can redeem 25M
+        address _treasury = portfolio.registry().treasury();
+        assertEq(usdc.balanceOf(_treasury), 0);
         vm.prank(board);
         portfolio.takeFees(5e6);
+        assertEq(usdc.balanceOf(_treasury), 5e6);
 
         assertEq(portfolio.convertToAssets(portfolio.balanceOf(alice)), 25e6 - 2); // -2 from rounding error.
         assertEq(portfolio.totalAssets(), 25e6 - 2); // -2 from rounding error.

--- a/src/test/CompoundV3USDCPortfolio.fork.t.sol
+++ b/src/test/CompoundV3USDCPortfolio.fork.t.sol
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: BSD 3-Clause
+pragma solidity 0.8.13;
+
+import "./utils/DeployTest.sol";
+import "../Registry.sol";
+import {IComet} from "../interfaces/ICErc20.sol";
+import {ERC20} from "solmate/tokens/ERC20.sol";
+import {SafeTransferLib} from "solmate/utils/SafeTransferLib.sol";
+import {CompoundV3USDCPortfolio} from "../portfolios/CompoundV3USDCPortfolio.sol";
+
+error DepositAfterShutdown();
+error SyncAfterShutdown();
+
+contract CompoundV3USDCPortfolioTest is DeployTest {
+    CompoundV3USDCPortfolio portfolio;
+    Fund fund;
+
+    ERC20 usdc = ERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+    IComet cusdc = IComet(0xc3d688B66703497DAA19211EEdff47f25384cdc3);
+    address manager = user1;
+    uint256 fundBalance = 1e27;
+
+    // cUSDC exchange rates at block 14500000
+    uint256 exchangeRateStored = 225506684689544;
+    uint256 exchangeRateCurrent = 225506689445887;
+
+    function setUp() public virtual override {
+        uint256 mainnetForkBlock = 17130422;
+        vm.createSelectFork(vm.rpcUrl("mainnet"), mainnetForkBlock);
+        super.setUp();
+
+        // Deploy new contracts with mainnet base token.
+        globalTestRegistry = new Registry(board, treasury, usdc);
+        orgFundFactory = new OrgFundFactory(globalTestRegistry);
+        vm.prank(board);
+        globalTestRegistry.setFactoryApproval(address(orgFundFactory), true);
+
+        // set donation fees to 0
+        // although it would be easier to do this in DeployTest, it causes testFuzz_UnmappedDefaultDonationFee to fail
+        vm.startPrank(board);
+        globalTestRegistry.setDefaultDonationFee(FundType, 0);
+        globalTestRegistry.setDefaultDonationFee(OrgType, 0);
+        vm.stopPrank();
+
+        // deploy a provisioned fund
+        fund = orgFundFactory.deployFund(manager, "soy sauce");
+        deal(address(usdc), manager, fundBalance);
+        vm.startPrank(manager);
+        usdc.approve(address(fund), fundBalance);
+        fund.donate(fundBalance);
+        vm.stopPrank();
+
+        // deploy portfolio
+        portfolio = new CompoundV3USDCPortfolio(globalTestRegistry, address(usdc), type(uint256).max, 0, 0);
+        vm.prank(board);
+        globalTestRegistry.setPortfolioStatus(portfolio, true);
+    }
+}
+
+contract CUPConstructor is CompoundV3USDCPortfolioTest {
+    function testFuzz_Constructor(uint256 _cap, uint256 _depositFee, uint256 _redemptionFee) public {
+        _redemptionFee = bound(_redemptionFee, 0, Math.ZOC);
+        CompoundV3USDCPortfolio _portfolio =
+            new CompoundV3USDCPortfolio(globalTestRegistry, address(usdc), _cap, _depositFee, _redemptionFee);
+
+        assertEq(_portfolio.name(), "Compound III USDC Portfolio Shares");
+        assertEq(_portfolio.symbol(), "cUSDCv3-PS");
+        assertEq(_portfolio.decimals(), usdc.decimals());
+        assertEq(_portfolio.asset(), address(usdc));
+        assertEq(_portfolio.cap(), _cap);
+        assertEq(_portfolio.depositFee(), _depositFee);
+        assertEq(_portfolio.redemptionFee(), _redemptionFee);
+        assertEq(_portfolio.totalAssets(), 0);
+        assertEq(_portfolio.convertToAssets(1e6), 1e6); // Starts at 1:1
+    }
+}
+
+contract CUPIntegrationTest is CompoundV3USDCPortfolioTest {
+    using stdStorage for StdStorage;
+
+    address alice = address(0xaffab1e);
+    address bob = address(0xbaff1ed);
+
+    function setUp() public override {
+        super.setUp();
+        deal(address(usdc), alice, 100e6);
+        deal(address(usdc), bob, 100e6);
+
+        vm.prank(alice);
+        usdc.approve(address(portfolio), type(uint256).max);
+
+        vm.prank(bob);
+        usdc.approve(address(portfolio), type(uint256).max);
+
+        stdstore.target(address(globalTestRegistry)).sig("isActiveEntity(address)").with_key(alice).checked_write(true);
+        stdstore.target(address(globalTestRegistry)).sig("isActiveEntity(address)").with_key(bob).checked_write(true);
+    }
+
+    function deposit(address _who, uint256 _usdcAmount) public returns (uint256) {
+        vm.prank(_who);
+        return portfolio.deposit(_usdcAmount, hex"");
+    }
+
+    function redeem(address _who) public returns (uint256) {
+        uint256 _shares = portfolio.balanceOf(_who);
+        vm.prank(_who);
+        return portfolio.redeem(_shares, hex"");
+    }
+
+    function test_Integration() public {
+        // 1. Alice deposits 30M, exchange rate should be 1:1
+        uint256 _aliceShares = deposit(alice, 30e6);
+        assertEq(_aliceShares, 30e6);
+        assertEq(portfolio.balanceOf(alice), _aliceShares);
+        assertEq(portfolio.convertToAssets(portfolio.balanceOf(alice)), 30e6 - 1); // -1 from rounding error.
+        assertEq(portfolio.convertToShares(30e6), portfolio.balanceOf(alice) + 1); // +1 from rounding error.
+        assertEq(portfolio.totalSupply(), _aliceShares);
+        assertEq(portfolio.totalAssets(), _aliceShares - 1); // -1 again from rounding error.
+
+        // 2. Endaoment takes 5M fees, Alice now can redeem 25M
+        vm.prank(board);
+        portfolio.takeFees(5e6);
+
+        assertEq(portfolio.convertToAssets(portfolio.balanceOf(alice)), 25e6 - 2); // -2 from rounding error.
+        assertEq(portfolio.totalAssets(), 25e6 - 2); // -2 from rounding error.
+        assertEq(portfolio.totalSupply(), _aliceShares);
+
+        // 3. Bob deposits 60M, Alice position remains unchanged
+        uint256 _bobShares = deposit(bob, 60e6);
+
+        // Same assertions about Alice's position
+        assertEq(_aliceShares, 30e6);
+        assertEq(portfolio.balanceOf(alice), _aliceShares);
+        assertEq(portfolio.convertToAssets(portfolio.balanceOf(alice)), 25e6 - 3); // -3 from rounding error.
+        assertEq(portfolio.totalAssets(), 85e6 - 3); // -3 from rounding error.
+        assertEq(portfolio.totalSupply(), _aliceShares + _bobShares);
+        assertEq(portfolio.totalSupply(), 102e6 + 5); // +5 from rounding error.
+
+        // New assertions about Bob's position
+        assertEq(portfolio.balanceOf(bob), _bobShares);
+        assertEq(portfolio.convertToAssets(portfolio.balanceOf(bob)), 60e6 - 1); // -1 from rounding error.
+
+        // 4. Increase the Portfolio's cUSDC balance to simulate returns.
+        // We do this by pranking from a mainnet cUSDC whale and transferring it to the portfolio, because cTokens
+        // have a dynamic balanceOf method so `deal` doesn't work.
+        uint256 _startBalance = portfolio.totalAssets();
+        address whale = 0xa2A0be8C7b9786d58CC1d3CDCfD27b351244281E; // Random whale with lots of cUSDC V3.
+        vm.prank(whale);
+        cusdc.transfer(address(portfolio), 100e6);
+        assertGt(portfolio.totalAssets(), _startBalance);
+
+        // 5. Alice and Bob should should get proportional amounts of USDC.
+        // Zero out their balances to simplify the math.
+        deal(address(usdc), alice, 0);
+        deal(address(usdc), bob, 0);
+
+        uint256 _aliceExpected = portfolio.totalAssets() * _aliceShares / portfolio.totalSupply();
+        uint256 _bobExpected = portfolio.totalAssets() * _bobShares / portfolio.totalSupply();
+
+        uint256 _aliceNet = redeem(alice);
+        uint256 _bobNet = redeem(bob);
+
+        assertEq(_aliceNet, _aliceExpected);
+        assertEq(_bobNet, _bobExpected);
+        assertEq(usdc.balanceOf(address(portfolio)), 0);
+    }
+
+    function testFuzz_DepositFailDidShutdown(uint256 _amount) public {
+        _amount = bound(_amount, 1, 1e7 ether);
+        bytes memory _data = hex"";
+
+        // shutdown
+        vm.prank(board);
+        portfolio.shutdown(_data);
+
+        // try to deposit
+        vm.prank(manager);
+        vm.expectRevert(DepositAfterShutdown.selector);
+        fund.portfolioDeposit(portfolio, _amount, _data);
+    }
+
+    function test_SyncFailDidShutdown() public {
+        bytes memory _data = hex"";
+
+        // shutdown
+        vm.prank(board);
+        portfolio.shutdown(_data);
+
+        // try to sync
+        vm.prank(board);
+        vm.expectRevert(SyncAfterShutdown.selector);
+        portfolio.sync();
+    }
+}

--- a/src/test/CompoundV3USDCPortfolio.fork.t.sol
+++ b/src/test/CompoundV3USDCPortfolio.fork.t.sol
@@ -98,13 +98,13 @@ contract CUPV3IntegrationTest is CompoundV3USDCPortfolioTest {
 
     function deposit(address _who, uint256 _usdcAmount) public returns (uint256) {
         vm.prank(_who);
-        return portfolio.deposit(_usdcAmount, hex"");
+        return portfolio.deposit(_usdcAmount, abi.encode(0));
     }
 
     function redeem(address _who) public returns (uint256) {
         uint256 _shares = portfolio.balanceOf(_who);
         vm.prank(_who);
-        return portfolio.redeem(_shares, hex"");
+        return portfolio.redeem(_shares, abi.encode(0));
     }
 
     function test_Integration() public {
@@ -166,6 +166,20 @@ contract CUPV3IntegrationTest is CompoundV3USDCPortfolioTest {
         assertEq(_aliceNet, _aliceExpected);
         assertEq(_bobNet, _bobExpected);
         assertEq(usdc.balanceOf(address(portfolio)), 0);
+    }
+
+    function test_RevertIf_DepositSlippageTooHigh() public {
+        vm.prank(alice);
+        vm.expectRevert(CompoundV3USDCPortfolio.Slippage.selector);
+        portfolio.deposit(30e6, abi.encode(31e6));
+    }
+
+    function test_RevertIf_RedeemSlippageTooHigh() public {
+        uint256 _shares = deposit(alice, 30e6);
+
+        vm.prank(alice);
+        vm.expectRevert(CompoundV3USDCPortfolio.Slippage.selector);
+        portfolio.redeem(_shares, abi.encode(31e6));
     }
 
     function testFuzz_DepositFailDidShutdown(uint256 _amount) public {

--- a/src/test/Entity.t.sol
+++ b/src/test/Entity.t.sol
@@ -126,7 +126,7 @@ abstract contract EntityTokenTransactionTest is EntityHarness {
         vm.expectEmit(true, true, true, true);
         emit EntityDonationReceived(
             _donor, address(entity), address(_baseToken), _donationAmount, _donationAmount, _amountFee
-            );
+        );
         deal(address(_baseToken), _donor, _donationAmount);
         vm.prank(_donor);
         entity.donate(_donationAmount);
@@ -162,7 +162,7 @@ abstract contract EntityTokenTransactionTest is EntityHarness {
         vm.expectEmit(true, true, true, true);
         emit EntityDonationReceived(
             _donor, address(entity), address(_baseToken), _donationAmount, _donationAmount, _amountFee
-            );
+        );
         deal(address(_baseToken), _donor, _donationAmount);
         vm.prank(_donor);
         entity.donateWithOverrides(_donationAmount);
@@ -188,7 +188,7 @@ abstract contract EntityTokenTransactionTest is EntityHarness {
         vm.expectEmit(true, true, true, true);
         emit EntityDonationReceived(
             _donor, address(entity), address(_baseToken), _donationAmount, _donationAmount, _amountFee
-            );
+        );
         vm.prank(_donor);
         entity.donateWithAdminOverrides(_donationAmount, uint32(_feePercent));
         assertEq(_baseToken.balanceOf(_donor), 0);
@@ -964,7 +964,7 @@ abstract contract EntityTokenTransactionTest is EntityHarness {
         vm.expectEmit(true, true, true, true);
         emit EntityDonationReceived(
             _donor, address(entity), address(testToken1), _donationAmount, mockSwapWrapper.amountOut(), _expectedFee
-            );
+        );
         vm.prank(_donor);
         entity.swapAndDonate(mockSwapWrapper, address(testToken1), _donationAmount, "");
 
@@ -1009,7 +1009,7 @@ abstract contract EntityTokenTransactionTest is EntityHarness {
             _donationAmount,
             mockSwapWrapper.amountOut(),
             _expectedFee
-            );
+        );
         vm.prank(_donor);
         entity.swapAndDonate{value: _donationAmount}(mockSwapWrapper, entity.ETH_PLACEHOLDER(), _donationAmount, "");
 
@@ -1087,7 +1087,7 @@ abstract contract EntityTokenTransactionTest is EntityHarness {
         vm.expectEmit(true, true, true, true);
         emit EntityDonationReceived(
             _donor, address(entity), address(testToken1), _donationAmount, mockSwapWrapper.amountOut(), _expectedFee
-            );
+        );
         vm.prank(_donor);
         entity.swapAndDonateWithOverrides(mockSwapWrapper, address(testToken1), _donationAmount, "");
 
@@ -1135,7 +1135,7 @@ abstract contract EntityTokenTransactionTest is EntityHarness {
             _donationAmount,
             mockSwapWrapper.amountOut(),
             _expectedFee
-            );
+        );
         vm.prank(_donor);
         entity.swapAndDonateWithOverrides{value: _donationAmount}(
             mockSwapWrapper,


### PR DESCRIPTION
Adds portfolios for Aave V3 USDC and Compound III (Coment) USDC, with mainnet fork tests. Deploy scripts will come in a separate PR to keep things small/well scoped. The contracts and tests are based on the original existing portfolio contracts/tests. As a result, an easier way to review this PR (instead of reading this diff) is to instead diff the new V3 version of a file against the original V2 version of it. One way to do this is:
- Use VSCode and install [this extension](https://marketplace.visualstudio.com/items?itemName=ryu1kn.partial-diff)
- Open an original file (such as `CompoundUSDCPortfolio.sol`) and copy the whole thing to your clipboard
- Open the new file (such as `CompoundV3USDCPortfolio.sol), go to PartialDiff > Compare Text With Clipboard to view the diff
- Repeat for all pairs of files:
   - `CompoundUSDCPortfolio.sol` and `CompoundV3USDCPortfolio.sol`
   - `AaveUSDCPortfolio.sol` and `AaveV3USDCPortfolio.sol`
   - `CompoundUSDCPortfolio.fork.t.sol` and `CompoundV3USDCPortfolio.fork.t.sol`
   - `AaveUSDCPortfolio.fork.t.sol` and `AaveV3USDCPortfolio.fork.t.sol`

We use the arbitrary `bytes` param of the deposit/redeem methods to account for slippage

One note is that I was surprised at how much rounding error there was in the compound v3 portfolio (up to 5 wei) so want to look into that before merging 

Edit: seems the rounding error is from compound—as soon as we give it 30k USDC we only get 29999 cUSDC back, so not much we can do here